### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/fx-onscreen-keyboard-swing/src/main/java/org/comtel2000/swing/ui/KeyboardEditorPaneUI.java
+++ b/fx-onscreen-keyboard-swing/src/main/java/org/comtel2000/swing/ui/KeyboardEditorPaneUI.java
@@ -47,12 +47,12 @@ public class KeyboardEditorPaneUI extends BasicEditorPaneUI {
 
 	private static MouseListener ml = null;
 
-	public static void setFocusListener(FocusListener l) {
-		fl = l;
-	}
-
 	public KeyboardEditorPaneUI() {
 		super();
+	}
+
+	public static void setFocusListener(FocusListener l) {
+		fl = l;
 	}
 
 	public static void setMouseListener(MouseListener l) {

--- a/fx-onscreen-keyboard-swing/src/main/java/org/comtel2000/swing/ui/KeyboardPasswordFieldUI.java
+++ b/fx-onscreen-keyboard-swing/src/main/java/org/comtel2000/swing/ui/KeyboardPasswordFieldUI.java
@@ -47,16 +47,16 @@ public class KeyboardPasswordFieldUI extends BasicPasswordFieldUI {
 
 	private static MouseListener ml = null;
 
+	public KeyboardPasswordFieldUI() {
+		super();
+	}
+
 	public static void setFocusListener(FocusListener l) {
 		fl = l;
 	}
 
 	public static void setMouseListener(MouseListener l) {
 		ml = l;
-	}
-
-	public KeyboardPasswordFieldUI() {
-		super();
 	}
 
 	public static ComponentUI createUI(JComponent c) {

--- a/fx-onscreen-keyboard-swing/src/main/java/org/comtel2000/swing/ui/KeyboardTextAreaUI.java
+++ b/fx-onscreen-keyboard-swing/src/main/java/org/comtel2000/swing/ui/KeyboardTextAreaUI.java
@@ -47,16 +47,16 @@ public class KeyboardTextAreaUI extends BasicTextAreaUI {
 
 	private static MouseListener ml = null;
 
+	public KeyboardTextAreaUI() {
+		super();
+	}
+
 	public static void setFocusListener(FocusListener l) {
 		fl = l;
 	}
 
 	public static void setMouseListener(MouseListener l) {
 		ml = l;
-	}
-
-	public KeyboardTextAreaUI() {
-		super();
 	}
 
 	public static ComponentUI createUI(JComponent c) {

--- a/fx-onscreen-keyboard-swing/src/main/java/org/comtel2000/swing/ui/KeyboardTextFieldUI.java
+++ b/fx-onscreen-keyboard-swing/src/main/java/org/comtel2000/swing/ui/KeyboardTextFieldUI.java
@@ -47,16 +47,16 @@ public class KeyboardTextFieldUI extends BasicTextFieldUI {
 
 	private static MouseListener ml = null;
 
+	public KeyboardTextFieldUI() {
+		super();
+	}
+
 	public static void setFocusListener(FocusListener l) {
 		fl = l;
 	}
 
 	public static void setMouseListener(MouseListener l) {
 		ml = l;
-	}
-
-	public KeyboardTextFieldUI() {
-		super();
 	}
 
 	public static ComponentUI createUI(JComponent c) {

--- a/fx-onscreen-keyboard/src/main/java/org/comtel2000/keyboard/control/KeyboardPane.java
+++ b/fx-onscreen-keyboard/src/main/java/org/comtel2000/keyboard/control/KeyboardPane.java
@@ -144,6 +144,10 @@ public class KeyboardPane extends Region implements StandardKeyCode, EventHandle
 
 	private final KeyboardLayoutHandler handler;
 
+	private MouseMovedHandler movedHandler;
+
+	private MouseDraggedHandler draggedHandler;
+
 	public KeyboardPane() {
 		getStyleClass().add("key-background");
 		setFocusTraversable(false);
@@ -915,9 +919,6 @@ public class KeyboardPane extends Region implements StandardKeyCode, EventHandle
 	public void setCacheLayout(boolean c) {
 		cacheLayoutProperty().set(c);
 	}
-
-	private MouseMovedHandler movedHandler;
-	private MouseDraggedHandler draggedHandler;
 
 	private void installMoveHandler(Node node) {
 		if (movedHandler == null) {

--- a/fx-onscreen-keyboard/src/main/java/org/comtel2000/keyboard/control/MultiKeyPopup.java
+++ b/fx-onscreen-keyboard/src/main/java/org/comtel2000/keyboard/control/MultiKeyPopup.java
@@ -54,6 +54,15 @@ class MultiKeyPopup extends Popup {
 
 	public static final String DEFAULT_STYLE_CLASS = "key-context-background";
 
+	private ObjectProperty<EventHandler<ActionEvent>> onAction = new SimpleObjectProperty<EventHandler<ActionEvent>>() {
+
+		@Override
+		protected void invalidated() {
+			setEventHandler(ActionEvent.ACTION, get());
+		}
+
+	};
+
 	MultiKeyPopup() {
 		// setAnchorLocation(AnchorLocation.CONTENT_TOP_LEFT);
 		buttonPane = new TilePane();
@@ -152,14 +161,5 @@ class MultiKeyPopup extends Popup {
 			Event.fireEvent(this, new Event(Menu.ON_HIDDEN));
 		}
 	}
-
-	private ObjectProperty<EventHandler<ActionEvent>> onAction = new SimpleObjectProperty<EventHandler<ActionEvent>>() {
-
-		@Override
-		protected void invalidated() {
-			setEventHandler(ActionEvent.ACTION, get());
-		}
-
-	};
 
 }

--- a/fx-onscreen-keyboard/src/main/java/org/comtel2000/keyboard/event/KeyButtonEvent.java
+++ b/fx-onscreen-keyboard/src/main/java/org/comtel2000/keyboard/event/KeyButtonEvent.java
@@ -42,6 +42,12 @@ public class KeyButtonEvent extends Event {
 
 	private static final long serialVersionUID = 647301812232489628L;
 
+	public static final EventType<Event> ANY;
+
+	public static final EventType<Event> LONG_PRESSED;
+
+	public static final EventType<Event> SHORT_PRESSED;
+
 	public KeyButtonEvent(EventType<Event> type) {
 		super(type);
 	}
@@ -59,12 +65,6 @@ public class KeyButtonEvent extends Event {
 		stringbuilder.append(", consumed = ").append(isConsumed());
 		return stringbuilder.append("]").toString();
 	}
-
-	public static final EventType<Event> ANY;
-
-	public static final EventType<Event> LONG_PRESSED;
-
-	public static final EventType<Event> SHORT_PRESSED;
 
 	static {
 		ANY = new EventType<Event>(Event.ANY, "KB_PRESSED");

--- a/fx-onscreen-keyboard/src/main/java/org/comtel2000/keyboard/event/OnScreenKeyEvent.java
+++ b/fx-onscreen-keyboard/src/main/java/org/comtel2000/keyboard/event/OnScreenKeyEvent.java
@@ -43,6 +43,12 @@ public class OnScreenKeyEvent extends InputEvent {
 
 	private static final long serialVersionUID = 65116620766495525L;
 
+	public static final EventType<? super Event> ANY;
+
+	public static final EventType<? super Event> LONG_PRESSED;
+
+	public static final EventType<? super Event> SHORT_PRESSED;
+
 	public OnScreenKeyEvent(EventType<? extends InputEvent> type) {
 		super(type);
 	}
@@ -61,12 +67,6 @@ public class OnScreenKeyEvent extends InputEvent {
 		stringbuilder.append(", consumed = ").append(isConsumed());
 		return stringbuilder.append("]").toString();
 	}
-
-	public static final EventType<? super Event> ANY;
-
-	public static final EventType<? super Event> LONG_PRESSED;
-
-	public static final EventType<? super Event> SHORT_PRESSED;
 
 	static {
 		ANY = new EventType<Event>(Event.ANY, "KB_PRESSED");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat