### PR TITLE
squid:S106 - Standard outputs should not be used directly to log anyt…

### DIFF
--- a/fx-onscreen-keyboard-samples/src/main/java/org/comtel2000/samples/fx/StandAloneApp.java
+++ b/fx-onscreen-keyboard-samples/src/main/java/org/comtel2000/samples/fx/StandAloneApp.java
@@ -49,8 +49,11 @@ import javafx.scene.Group;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class StandAloneApp extends Application {
+	private static final Logger LOGGER = LoggerFactory.getLogger(StandAloneApp.class);
 
 	private int posX = 0, posY = 0;
 
@@ -92,7 +95,7 @@ public class StandAloneApp extends Application {
 			kb.load();
 
 		} catch (Exception e) {
-			System.out.println(e.getMessage());
+			LOGGER.error(e.getMessage());
 			showHelp();
 		}
 
@@ -111,13 +114,13 @@ public class StandAloneApp extends Application {
 	}
 
 	private void showHelp() {
-		System.out.println();
-		System.out.println("\t--scale=<double>\tset the intial scale");
-		System.out.println("\t--lang=<locale>\t\tsetting keyboard language (en,de,ru,..)");
-		System.out.println("\t--layout=<path>\t\tpath to custom layout xml");
-		System.out.println("\t--pos=<x,y>\t\tinitial keyboard position");
-		System.out.println("\t--type=<type>\t\tvkType like numeric, email, url, text(default)");
-		System.out.println("\t--help\t\t\tthis help screen");
+		LOGGER.debug("\n");
+		LOGGER.debug("\t--scale=<double>\tset the intial scale");
+		LOGGER.debug("\t--lang=<locale>\t\tsetting keyboard language (en,de,ru,..)");
+		LOGGER.debug("\t--layout=<path>\t\tpath to custom layout xml");
+		LOGGER.debug("\t--pos=<x,y>\t\tinitial keyboard position");
+		LOGGER.debug("\t--type=<type>\t\tvkType like numeric, email, url, text(default)");
+		LOGGER.debug("\t--help\t\t\tthis help screen");
 		System.exit(0);
 	}
 

--- a/fx-onscreen-keyboard-samples/src/main/java/org/comtel2000/samples/swing/StandAloneApp.java
+++ b/fx-onscreen-keyboard-samples/src/main/java/org/comtel2000/samples/swing/StandAloneApp.java
@@ -55,8 +55,11 @@ import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
 import javafx.scene.Group;
 import javafx.scene.Scene;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class StandAloneApp extends JApplet {
+	private static final Logger LOGGER = LoggerFactory.getLogger(StandAloneApp.class);
 
 	private static String[] arguments;
 	private int posX = 0, posY = 0;
@@ -128,7 +131,7 @@ public class StandAloneApp extends JApplet {
 			kb.load();
 
 		} catch (Exception e) {
-			System.out.println(e.getMessage());
+			LOGGER.error(e.getMessage());
 			showHelp();
 		}
 
@@ -140,13 +143,13 @@ public class StandAloneApp extends JApplet {
 	}
 
 	private void showHelp() {
-		System.out.println();
-		System.out.println("\t--scale=<double>\tset the intial scale");
-		System.out.println("\t--lang=<locale>\t\tsetting keyboard language (en,de,ru,..)");
-		System.out.println("\t--layout=<path>\t\tpath to custom layout xml");
-		System.out.println("\t--pos=<x,y>\t\tinitial keyboard position");
-		System.out.println("\t--type=<type>\t\tvkType like numeric, email, url, text(default)");
-		System.out.println("\t--help\t\t\tthis help screen");
+		LOGGER.debug("\n");
+		LOGGER.debug("\t--scale=<double>\tset the intial scale");
+		LOGGER.debug("\t--lang=<locale>\t\tsetting keyboard language (en,de,ru,..)");
+		LOGGER.debug("\t--layout=<path>\t\tpath to custom layout xml");
+		LOGGER.debug("\t--pos=<x,y>\t\tinitial keyboard position");
+		LOGGER.debug("\t--type=<type>\t\tvkType like numeric, email, url, text(default)");
+		LOGGER.debug("\t--help\t\t\tthis help screen");
 		System.exit(0);
 	}
 

--- a/fx-onscreen-keyboard/src/test/java/org/comtel2000/keyboard/KeyboardXmlLayoutTest.java
+++ b/fx-onscreen-keyboard/src/test/java/org/comtel2000/keyboard/KeyboardXmlLayoutTest.java
@@ -48,8 +48,11 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class KeyboardXmlLayoutTest {
+	private static final Logger LOGGER = LoggerFactory.getLogger(KeyboardXmlLayoutTest.class);
 
 	private static KeyboardLayoutHandler handler;
 
@@ -70,9 +73,9 @@ public class KeyboardXmlLayoutTest {
 		Assert.assertFalse(kb.getRow().isEmpty());
 
 		for (Keyboard.Row row : kb.getRow()) {
-			System.err.println("\nRow " + row.getRowEdgeFlags());
+			LOGGER.debug("\nRow " + row.getRowEdgeFlags());
 			for (Keyboard.Row.Key key : row.getKey()) {
-				System.err.println(key.getCodes() + "\t" + (key.getKeyLabel() != null ? key.getKeyLabel() : key.getKeyIconStyle()));
+				LOGGER.debug(key.getCodes() + "\t" + (key.getKeyLabel() != null ? key.getKeyLabel() : key.getKeyIconStyle()));
 			}
 		}
 	}
@@ -96,7 +99,7 @@ public class KeyboardXmlLayoutTest {
 			stream.forEach(p -> {
 				if (Files.isDirectory(p)) {
 					Locale l = new Locale(p.getFileName().toString());
-					System.err.println(l);
+					LOGGER.debug(l.toString());
 				}
 			});
 		}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S106 - Standard outputs should not be used directly to log anything

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S106

Please let me know if you have any questions.

M-Ezzat