### PR TITLE
squid:CommentedOutCodeLine - Sections of code should not be "commente…

### DIFF
--- a/fx-onscreen-keyboard-samples/src/main/java/org/comtel2000/samples/fx/StandAloneApp.java
+++ b/fx-onscreen-keyboard-samples/src/main/java/org/comtel2000/samples/fx/StandAloneApp.java
@@ -99,7 +99,6 @@ public class StandAloneApp extends Application {
 
     popup.registerScene(scene);
     popup.setVisible(true);
-    // popup.show(stage);
 
   }
 

--- a/fx-onscreen-keyboard-samples/src/main/java/org/comtel2000/samples/swing/SwingDemo.java
+++ b/fx-onscreen-keyboard-samples/src/main/java/org/comtel2000/samples/swing/SwingDemo.java
@@ -58,7 +58,6 @@ public class SwingDemo extends JApplet implements VkProperties {
 
     KeyBoardWindow window =
         KeyBoardWindowBuilder.create().initLocale(Locale.forLanguageTag("en")).addIRobot(new AWTRobotHandler()).layer(DefaultLayer.NUMBLOCK).build();
-    // window.getKeyBoardPopup().get().getKeyBoard().setOnKeyboardCloseButton(window.getKeyBoardPopup().get().defaultCloseHandler);
     KeyboardUIManagerTool.installKeyboardDefaults(window);
 
     JPanel panel = new JPanel();

--- a/fx-onscreen-keyboard/src/main/java/org/comtel2000/keyboard/control/KeyboardPane.java
+++ b/fx-onscreen-keyboard/src/main/java/org/comtel2000/keyboard/control/KeyboardPane.java
@@ -452,7 +452,6 @@ public class KeyboardPane extends Region implements StandardKeyCode, EventHandle
 
     GridPane rPane = new GridPane();
     rPane.setAlignment(Pos.CENTER);
-    // pane.setPrefSize(600, 200);
 
     if (layout.getVerticalGap() != null) {
       rPane.setVgap(layout.getVerticalGap());
@@ -474,8 +473,6 @@ public class KeyboardPane extends Region implements StandardKeyCode, EventHandle
       int colIdx = 0;
       GridPane colPane = new GridPane();
       colPane.getStyleClass().add("key-background-column");
-      // colPane.setVgap(20);
-      // colPane.setPrefWidth(Region.USE_COMPUTED_SIZE);
 
       RowConstraints rc = new RowConstraints();
       rc.setPrefHeight(defaultKeyHeight);
@@ -525,7 +522,6 @@ public class KeyboardPane extends Region implements StandardKeyCode, EventHandle
 
         button.setFocusTraversable(false);
         button.setOnShortPressed(this);
-        // button.setCache(true);
 
         button.setMinHeight(10);
         button.setPrefHeight(defaultKeyHeight);
@@ -566,9 +562,6 @@ public class KeyboardPane extends Region implements StandardKeyCode, EventHandle
         if (key.getKeyIconStyle() != null && key.getKeyIconStyle().startsWith(".")) {
           logger.trace("Load css style: {}", key.getKeyIconStyle());
           Label icon = new Label();
-          // icon.setSnapToPixel(true);
-          // do not reduce css shape quality JavaFX8
-          // icon.setCacheShape(false);
 
           for (String style : key.getKeyIconStyle().split(";")) {
             icon.getStyleClass().add(style.substring(1));
@@ -617,7 +610,6 @@ public class KeyboardPane extends Region implements StandardKeyCode, EventHandle
           case DELETE:
             if (!button.isRepeatable()) {
               button.setOnLongPressed(e -> {
-                // e.consume();
                 sendToComponent((char) 97, true);
                 sendToComponent((char) java.awt.event.KeyEvent.VK_DELETE, isControl());
               });
@@ -636,7 +628,6 @@ public class KeyboardPane extends Region implements StandardKeyCode, EventHandle
       }
       logger.trace("row[{}] - {}", rowIdx, rowWidth);
       colPane.getRowConstraints().add(rc);
-      // colPane.setGridLinesVisible(true);
       rPane.add(colPane, 0, rowIdx);
       rowIdx++;
     }

--- a/fx-onscreen-keyboard/src/main/java/org/comtel2000/keyboard/control/MultiKeyButton.java
+++ b/fx-onscreen-keyboard/src/main/java/org/comtel2000/keyboard/control/MultiKeyButton.java
@@ -101,7 +101,6 @@ class MultiKeyButton extends KeyButton {
       });
       setOnLongPressed(event -> {
 
-        // getParent().getParent().setEffect(new BoxBlur());
         getParent().getParent().setDisable(true);
         setFocused(false);
         context.show((Node) event.getSource(), scale);

--- a/fx-onscreen-keyboard/src/main/java/org/comtel2000/keyboard/control/MultiKeyPopup.java
+++ b/fx-onscreen-keyboard/src/main/java/org/comtel2000/keyboard/control/MultiKeyPopup.java
@@ -50,7 +50,6 @@ class MultiKeyPopup extends Popup {
   private ObjectProperty<EventHandler<ActionEvent>> onAction;
 
   MultiKeyPopup() {
-    // setAnchorLocation(AnchorLocation.CONTENT_TOP_LEFT);
     buttonPane = new TilePane();
     buttonPane.getStyleClass().add(DEFAULT_STYLE_CLASS);
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:CommentedOutCodeLine - Sections of code should not be "commented out"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:CommentedOutCodeLine

Please let me know if you have any questions.

M-Ezzat