### PR TITLE
squid:S3052 - Fields should not be initialized to default values

### DIFF
--- a/fx-onscreen-keyboard-samples/src/main/java/org/comtel2000/samples/fx/StandAloneApp.java
+++ b/fx-onscreen-keyboard-samples/src/main/java/org/comtel2000/samples/fx/StandAloneApp.java
@@ -45,7 +45,7 @@ import javafx.stage.StageStyle;
 
 public class StandAloneApp extends Application {
 
-  private int posX = 0, posY = 0;
+  private int posX, posY;
 
   @Override
   public void start(Stage stage) {

--- a/fx-onscreen-keyboard-samples/src/main/java/org/comtel2000/samples/swing/StandAloneApp.java
+++ b/fx-onscreen-keyboard-samples/src/main/java/org/comtel2000/samples/swing/StandAloneApp.java
@@ -52,7 +52,7 @@ import javafx.scene.Scene;
 public class StandAloneApp extends JApplet {
 
   private static String[] arguments;
-  private int posX = 0, posY = 0;
+  private int posX, posY;
 
   private static final long serialVersionUID = 1L;
 

--- a/fx-onscreen-keyboard-swing/src/main/java/org/comtel2000/swing/ui/KeyboardEditorPaneUI.java
+++ b/fx-onscreen-keyboard-swing/src/main/java/org/comtel2000/swing/ui/KeyboardEditorPaneUI.java
@@ -36,9 +36,9 @@ import javax.swing.text.JTextComponent;
 
 public class KeyboardEditorPaneUI extends BasicEditorPaneUI {
 
-  private static FocusListener fl = null;
+  private static FocusListener fl;
 
-  private static MouseListener ml = null;
+  private static MouseListener ml;
 
   public KeyboardEditorPaneUI() {
     super();

--- a/fx-onscreen-keyboard-swing/src/main/java/org/comtel2000/swing/ui/KeyboardPasswordFieldUI.java
+++ b/fx-onscreen-keyboard-swing/src/main/java/org/comtel2000/swing/ui/KeyboardPasswordFieldUI.java
@@ -36,9 +36,9 @@ import javax.swing.text.JTextComponent;
 
 public class KeyboardPasswordFieldUI extends BasicPasswordFieldUI {
 
-  private static FocusListener fl = null;
+  private static FocusListener fl;
 
-  private static MouseListener ml = null;
+  private static MouseListener ml;
 
   public KeyboardPasswordFieldUI() {
     super();

--- a/fx-onscreen-keyboard-swing/src/main/java/org/comtel2000/swing/ui/KeyboardTextAreaUI.java
+++ b/fx-onscreen-keyboard-swing/src/main/java/org/comtel2000/swing/ui/KeyboardTextAreaUI.java
@@ -36,9 +36,9 @@ import javax.swing.text.JTextComponent;
 
 public class KeyboardTextAreaUI extends BasicTextAreaUI {
 
-  private static FocusListener fl = null;
+  private static FocusListener fl;
 
-  private static MouseListener ml = null;
+  private static MouseListener ml;
 
   public KeyboardTextAreaUI() {
     super();

--- a/fx-onscreen-keyboard-swing/src/main/java/org/comtel2000/swing/ui/KeyboardTextFieldUI.java
+++ b/fx-onscreen-keyboard-swing/src/main/java/org/comtel2000/swing/ui/KeyboardTextFieldUI.java
@@ -36,9 +36,9 @@ import javax.swing.text.JTextComponent;
 
 public class KeyboardTextFieldUI extends BasicTextFieldUI {
 
-  private static FocusListener fl = null;
+  private static FocusListener fl;
 
-  private static MouseListener ml = null;
+  private static MouseListener ml;
 
   public KeyboardTextFieldUI() {
     super();

--- a/fx-onscreen-keyboard/src/main/java/org/comtel2000/keyboard/control/KeyButton.java
+++ b/fx-onscreen-keyboard/src/main/java/org/comtel2000/keyboard/control/KeyButton.java
@@ -48,10 +48,10 @@ public abstract class KeyButton extends Button implements LongPressable {
 
   protected Timeline buttonDelay;
 
-  private EventHandler<? super KeyButtonEvent> _onLongPressed = null;
+  private EventHandler<? super KeyButtonEvent> _onLongPressed;
   private ObjectProperty<EventHandler<? super KeyButtonEvent>> onLongPressed;
 
-  private EventHandler<? super KeyButtonEvent> _onShortPressed = null;
+  private EventHandler<? super KeyButtonEvent> _onShortPressed;
   private ObjectProperty<EventHandler<? super KeyButtonEvent>> onShortPressed;
 
   public KeyButton() {

--- a/fx-onscreen-keyboard/src/main/java/org/comtel2000/keyboard/control/KeyboardPane.java
+++ b/fx-onscreen-keyboard/src/main/java/org/comtel2000/keyboard/control/KeyboardPane.java
@@ -96,16 +96,16 @@ public class KeyboardPane extends Region implements StandardKeyCode, EventHandle
   private String _keyBoardStyle = DEFAULT_CSS;
   private StringProperty keyBoardStyle;
 
-  private boolean _cacheLayout = false;
+  private boolean _cacheLayout;
   private BooleanProperty cacheLayout;
 
-  private boolean _symbol = false;
+  private boolean _symbol;
   private BooleanProperty symbol;
 
-  private boolean _shift = false;
+  private boolean _shift;
   private BooleanProperty shift;
 
-  private boolean _control = false;
+  private boolean _control;
   private BooleanProperty control;
 
   private boolean _spaceKeyMove = true;
@@ -129,16 +129,16 @@ public class KeyboardPane extends Region implements StandardKeyCode, EventHandle
   private DefaultLayer _layer = DefaultLayer.DEFAULT;
   private ObjectProperty<DefaultLayer> layer;
 
-  private Path _layerPath = null;
+  private Path _layerPath;
   private ObjectProperty<Path> layerPath;
 
   private Locale _locale = Locale.getDefault();
   private ObjectProperty<Locale> locale;
 
-  private Locale _activeLocale = null;
+  private Locale _activeLocale;
   private ObjectProperty<Locale> activeLocale;
 
-  private KeyboardType _activeType = null;
+  private KeyboardType _activeType;
   private ObjectProperty<KeyboardType> activeType;
 
   private EventHandler<? super Event> closeEventHandler;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S3052 - Fields should not be initialized to default values

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S3052

Please let me know if you have any questions.

M-Ezzat