### PR TITLE
Do not actively generate build reports when not needed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
 		<javafx.version>17.0.1</javafx.version>
 		<junit.version>5.5.2</junit.version>
 		<slf4j.version>2.0.0-alpha6</slf4j.version>
+		<closeTestReports>true</closeTestReports>
 	</properties>
 
 	<modules>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
