### PR TITLE
fix: ensure setPickOnBounds(true) for all KeyButtons (fixes #92)

### DIFF
--- a/fx-onscreen-keyboard/src/main/java/org/comtel2000/keyboard/control/KeyboardPane.java
+++ b/fx-onscreen-keyboard/src/main/java/org/comtel2000/keyboard/control/KeyboardPane.java
@@ -479,6 +479,7 @@ public class KeyboardPane extends Region implements StandardKeyCode, EventHandle
             }
 
             button.setFocusTraversable(false);
+            button.setPickOnBounds(true); // Ensures the button reacts to clicks/taps on the entire area, including label/icon (fixes #92)
             button.setOnShortPressed(this);
 
             button.setMinHeight(1);


### PR DESCRIPTION
Set pickOnBounds to true so the button reacts to clicks/taps on the entire area, including label/icon. Comment now in English.