### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "dev" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/comtel2000/fx-experience/security/code-scanning/2](https://github.com/comtel2000/fx-experience/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root (recommended here since there is one job and shared minimal permissions are sufficient). For this workflow, the least-privilege baseline is:

- `contents: read`

This preserves existing behavior (`checkout`, setup Java, Maven test, and artifact upload on failure) while removing reliance on potentially broad defaults.

**Where to change:** `.github/workflows/ci.yml`, right after the `on:` trigger block and before `jobs:`.

**What to add:** a YAML `permissions` mapping with `contents: read`.  
No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
