### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ "dev" ]
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/comtel2000/fx-experience/security/code-scanning/1](https://github.com/comtel2000/fx-experience/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is least-privileged by default.  
Best single fix without changing functionality: define `permissions` at the workflow root with `contents: read` (the minimal recommended permission and sufficient for `actions/checkout` in this workflow). This preserves current behavior while preventing accidental broader token access if repo/org defaults change.

**File to edit:** `.github/workflows/maven-deploy.yml`  
**Change location:** right after the `on:` trigger block (before `jobs:`), add:
```yaml
permissions:
  contents: read
```
No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
